### PR TITLE
Use model output sample rate in speak.py

### DIFF
--- a/speak.py
+++ b/speak.py
@@ -62,7 +62,7 @@ def speak(text: str) -> None:
     text = _prepare_text(text)
     print(f"Speaking: {text}")
     wav = tts.tts(text=text)
-    sd.play(wav, samplerate=22050)
+    sd.play(wav, samplerate=tts.synthesizer.output_sample_rate)
     sd.wait()
 
 


### PR DESCRIPTION
## Summary
- fix hard-coded sample rate in `speak.py`

## Testing
- `python -m py_compile speak.py`

------
https://chatgpt.com/codex/tasks/task_e_683e85ed3e108329bb421e1a95e5ddcc